### PR TITLE
* Sync matches assigned status on assignment creation/deletion

### DIFF
--- a/backend/app/controllers/api/v1/admin/assignments_controller.rb
+++ b/backend/app/controllers/api/v1/admin/assignments_controller.rb
@@ -19,7 +19,24 @@ class Api::V1::Admin::AssignmentsController < ApplicationController
 
         @assignment = Assignment.new(assignment_params)
         render_on_condition(
-            object: @assignment, condition: proc { @assignment.save! }
+            object: @assignment,
+            condition:
+                proc do
+                    success = false
+                    Assignment.transaction do
+                        success = @assignment.save
+                        if success
+                            # Propagate assigned status true to any corresponding matches
+                            success = Match.sync_assigned_for(
+                                position_id: @assignment.position_id,
+                                applicant_id: @assignment.applicant_id,
+                                assigned: true
+                            )
+                        end
+                        raise ActiveRecord::Rollback unless success
+                    end
+                    success
+                end
         )
     end
 
@@ -37,6 +54,17 @@ class Api::V1::Admin::AssignmentsController < ApplicationController
                 assignment.update_column(:active_offer_id, nil)
                 assignment.offers.destroy_all
                 success = assignment.destroy
+
+                if success
+                    # Propagate assigned status false to any corresponding matches
+                    success = Match.sync_assigned_for(
+                        position_id: assignment.position_id,
+                        applicant_id: assignment.applicant_id,
+                        assigned: false
+                    )
+                end
+
+                raise ActiveRecord::Rollback unless success
             end
         end
 

--- a/backend/app/models/match.rb
+++ b/backend/app/models/match.rb
@@ -17,6 +17,16 @@ class Match < ApplicationRecord
     scope :tentative, -> { where(tentative: true) }
 
     validates_uniqueness_of :applicant_id, scope: %i[position_id]
+
+    # Helper function to sync assigned status on existing match upon assignment creation/deletion
+    def self.sync_assigned_for(position_id:, applicant_id:, assigned:)
+        match = find_by(position_id: position_id, applicant_id: applicant_id)
+        return true if match.nil? && !assigned
+
+        match ||= new(position_id: position_id, applicant_id: applicant_id)
+        match.assigned = assigned
+        match.save
+    end
 end
 
 # == Schema Information

--- a/backend/app/views/position_mailer/email_ddah_reminder.html
+++ b/backend/app/views/position_mailer/email_ddah_reminder.html
@@ -48,7 +48,6 @@
                 more information if you are a new Instructor.
             </li>
         </ol>
-        <br />
         <p>Thanks!</p>
         <br />
         <p>

--- a/frontend/src/views/admin/applications/application-details.tsx
+++ b/frontend/src/views/admin/applications/application-details.tsx
@@ -246,7 +246,7 @@ export function ApplicationDetails({
     const applicantMatchesTentative = React.useMemo(() => {
         return matches.filter(
             (match) =>
-                match.applicant === application.applicant && match.tentative
+                match.applicant === application.applicant && match.tentative && !match.assigned
         );
     }, [matches, application]);
 

--- a/frontend/src/views/instructor/preferences/applications-table.tsx
+++ b/frontend/src/views/instructor/preferences/applications-table.tsx
@@ -65,7 +65,7 @@ export function InstructorApplicationsTable() {
         React.useMemo(() => {
             const ret: Record<number, Match[]> = {};
             for (const match of matches) {
-                if (match.tentative) {
+                if (match.tentative && !match.assigned) {
                     ret[match.applicant.id] = ret[match.applicant.id] || [];
                     ret[match.applicant.id].push(match);
                 }


### PR DESCRIPTION
* Omit "actually" assigned matches from lists of tentative ones